### PR TITLE
Refactor reset password functionality and update metadata

### DIFF
--- a/src/app/(auth)/(student)/reset-password/page.tsx
+++ b/src/app/(auth)/(student)/reset-password/page.tsx
@@ -12,14 +12,15 @@ import { useTitle } from '@/providers/title.provider';
 import Image from 'next/image';
 import Link from 'next/link';
 import StudentAuthQueries from '../_module/student.auth.queries';
+import useURL from '@/hooks/useURL';
 
-
-export default function ResetPasswordPage({ searchParams }: { searchParams: { token: string } }) {
+export default function ResetPasswordPage() {
   const { setTitle } = useTitle()
+  const { searchParams } = useURL();
   const { resetPasswordMutation } = useStudentAuthMutations()
   const { useVerifyResetPasswordTokenQuery } = StudentAuthQueries()
 
-  const token = searchParams.token;
+  const token = searchParams.get('token') || '';
 
   const { data: tokenData, isPending, isError } = useVerifyResetPasswordTokenQuery(token)
 

--- a/src/app/(auth)/affiliate/_module/affiliate.auth.queries.tsx
+++ b/src/app/(auth)/affiliate/_module/affiliate.auth.queries.tsx
@@ -6,7 +6,7 @@ export const useVerifyResetPasswordTokenQuery = (token: string) => {
   const axiosHandler = useAxios();
   const query = useQuery({
     queryKey: ['verify-affiliate-reset-password-token'],
-    queryFn: () => axiosHandler.post(`/affiliate/auth/password/reset?token=${token}`),
+    queryFn: () => axiosHandler.get(`/affiliate/auth/password/reset?token=${token}`),
   })
 
   return query;

--- a/src/app/(auth)/affiliate/register/layout.tsx
+++ b/src/app/(auth)/affiliate/register/layout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from "react"
 
 export const metadata = {
-  title: 'Affiliate Register | The Grind Academy',
+  title: 'Affiliate Registration | The Grind Academy',
   description: 'Register to become an affiliate of The Grind Academy'
 }
 

--- a/src/app/(auth)/affiliate/reset-password/layout.tsx
+++ b/src/app/(auth)/affiliate/reset-password/layout.tsx
@@ -1,8 +1,8 @@
 import { ReactNode } from "react"
 
 export const metadata = {
-  title: 'Welcome to The Grind Academy',
-  description: 'Setup your account to continue'
+  title: 'Reset Password',
+  description: 'Reset your password'
 }
 
 export default function SetupAccountLayout({ children }: { children: ReactNode }) {

--- a/src/app/(auth)/affiliate/reset-password/page.tsx
+++ b/src/app/(auth)/affiliate/reset-password/page.tsx
@@ -13,13 +13,15 @@ import Link from 'next/link';
 import { useVerifyResetPasswordTokenQuery } from '../_module/affiliate.auth.queries';
 import useAffiliateAuthMutations from '../_module/affiliate.auth.mutations';
 import * as yup from 'yup';
+import useURL from '@/hooks/useURL';
 
 
-export default function ResetPasswordPage({ searchParams }: { searchParams: { token: string } }) {
+export default function ResetPasswordPage() {
   const { setTitle } = useTitle()
-  const { resetPasswordMutation } = useAffiliateAuthMutations()
+  const { searchParams } = useURL();
+  const { resetPasswordMutation } = useAffiliateAuthMutations();
 
-  const token = searchParams.token;
+  const token = searchParams.get('token') || '';
 
   const { data: tokenData, isPending, isError } = useVerifyResetPasswordTokenQuery(token)
 

--- a/src/app/(auth)/affiliate/verify/layout.tsx
+++ b/src/app/(auth)/affiliate/verify/layout.tsx
@@ -1,8 +1,8 @@
 import { ReactNode } from "react"
 
 export const metadata = {
-  title: 'Welcome to The Grind Academy',
-  description: 'Setup your account to continue'
+  title: 'Affiliate Account Verification | The Grind Academy',
+  description: 'Verify your account to continue'
 }
 
 export default function SetupAccountLayout({ children }: { children: ReactNode }) {

--- a/src/app/(auth)/i/_module/admin.auth.queries.tsx
+++ b/src/app/(auth)/i/_module/admin.auth.queries.tsx
@@ -6,7 +6,7 @@ export default function AdminAuthQueries() {
 
   const useVerifyResetPasswordTokenQuery = (token: string) => useQuery({
     queryKey: ['verify-reset-password-token'],
-    queryFn: () => axiosHandler.get(`/student/auth/password/reset?token=${token}`),
+    queryFn: () => axiosHandler.get(`/admin/auth/password/reset?token=${token}`),
   })
 
   return { useVerifyResetPasswordTokenQuery }

--- a/src/app/(auth)/i/reset-password/page.tsx
+++ b/src/app/(auth)/i/reset-password/page.tsx
@@ -12,14 +12,15 @@ import { useTitle } from '@/providers/title.provider';
 import Image from 'next/image';
 import Link from 'next/link';
 import AdminAuthQueries from '../_module/admin.auth.queries';
+import useURL from '@/hooks/useURL';
 
-
-export default function ResetPasswordPage({ searchParams }: { searchParams: { token: string } }) {
+export default function ResetPasswordPage() {
   const { setTitle } = useTitle()
+  const { searchParams } = useURL();
   const { resetPasswordMutation } = useAdminAuthMutations()
   const { useVerifyResetPasswordTokenQuery } = AdminAuthQueries()
 
-  const token = searchParams.token;
+  const token = searchParams.get('token') || '';
 
   const { data: tokenData, isPending, isError } = useVerifyResetPasswordTokenQuery(token)
 

--- a/src/hooks/useAxios.tsx
+++ b/src/hooks/useAxios.tsx
@@ -7,6 +7,7 @@ import storageUtil, { StorageKey } from '@/utils/storage.util';
 import { usePathname } from 'next/navigation';
 import useURL from './useURL';
 import { URLKeyEnum } from '@/app/_module/app.enum';
+import usePathFinder from './usePathFinder';
 
 export type MessageResponse = {
   message: string
@@ -32,7 +33,7 @@ const config: AxiosRequestConfig = {
 export default function useAxios() {
   const pathname = usePathname();
   const { updateParams } = useURL();
-  const loginPath = pathname.startsWith('/i') ? '/i/login' : '/login';
+  const { loginPath } = usePathFinder();
 
   const axiosInstance = axios.create(config);
 


### PR DESCRIPTION
- Simplified the ResetPasswordPage component by utilizing the useURL hook to retrieve search parameters.
- Changed the HTTP method from POST to GET for the reset password token verification in affiliate queries.
- Updated page metadata titles and descriptions for better clarity in affiliate and admin reset password layouts.
- Adjusted the token retrieval logic to ensure compatibility across different authentication contexts.