### PR TITLE
Refactor video upload mutation to improve parameter naming consistency

### DIFF
--- a/src/app/_module/app.mutations.tsx
+++ b/src/app/_module/app.mutations.tsx
@@ -20,10 +20,10 @@ export default function useAppMutations() {
   })
 
   const uploadVideoFileMutation = useMutation({
-    mutationFn: async (values: { file: File, type: VideoFileType }): Promise<string> => {
+    mutationFn: async (values: { file: File, fileType: VideoFileType }): Promise<string> => {
       const formData = new FormData();
       formData.append('file', values.file);
-      formData.append('type', values.type);
+      formData.append('fileType', values.fileType);
       const response = await axiosHandler.post('/file/bunny', formData, {
         headers: {
           'Content-Type': 'multipart/form-data'

--- a/src/components/FileUploader.tsx
+++ b/src/components/FileUploader.tsx
@@ -46,7 +46,7 @@ export default function FileUploader({ provider, type, fileType, onChange }: Fil
 
     if (file) {
       if (provider === 'bunny') {
-        uploadVideoFileMutation.mutate({ file, type: 'course' }, {
+        uploadVideoFileMutation.mutate({ file, fileType: 'course' }, {
           onSuccess: (data) => onChange(data)
         });
       } else {


### PR DESCRIPTION
- Changed the parameter name from 'type' to 'fileType' in the uploadVideoFileMutation for clarity.
- Updated the corresponding mutation call in FileUploader to reflect the new parameter name, ensuring consistency across the application.