### PR TITLE
Fix notification message for toggling subscription plan

### DIFF
--- a/src/app/i/website-content/subscription-plans/[id]/page.tsx
+++ b/src/app/i/website-content/subscription-plans/[id]/page.tsx
@@ -100,7 +100,7 @@ export default function SubscriptionPlanDetailPage({ params }: { params: { id: s
   const toggleDisabled = () => {
     updateSubscriptionPlanMutation.mutate({ ...values, id, isDisabled: !values.isDisabled }, {
       onSuccess: () => {
-        notificationUtil.success(`Subscription plan ${values.isDisabled ? 'disabled' : 'enabled'} successfully`);
+        notificationUtil.success(`Subscription plan ${!values.isDisabled ? 'disabled' : 'enabled'} successfully`);
       }
     });
   }


### PR DESCRIPTION
Corrects the success notification to accurately reflect the new state after toggling the subscription plan's disabled status.