### PR TITLE
Update subscription date handling to use datetime

### DIFF
--- a/src/app/i/_module/admin.mutations.tsx
+++ b/src/app/i/_module/admin.mutations.tsx
@@ -41,13 +41,11 @@ export default function useAdminMutations() {
 
   const createUserSubscriptionPlanMutation = useMutation({
     mutationFn: async (values: IUserSubscriptionPlanCreate) => {
-      const { userId, startDate, ...payload } = values;
-      // Append the current time to the provided startDate
-      const date = new Date(startDate!);
-      const now = new Date();
-      date.setHours(now.getHours(), now.getMinutes(), now.getSeconds(), now.getMilliseconds());
-      const adjustedStartDate = date.toISOString();
-      const response = await axiosHandler.post(`/admin/user/${userId}/subscription`, { ...payload, startDate: adjustedStartDate });
+      const { userId, ...payload } = values;
+      const date = new Date(payload.startDate!);
+      date.setMinutes(date.getMinutes() + 1);
+      payload.startDate = date.toISOString();
+      const response = await axiosHandler.post(`/admin/user/${userId}/subscription`, payload);
       return response.data
     },
     onSettled: (data, variables, context) => {
@@ -59,12 +57,10 @@ export default function useAdminMutations() {
   const updateUserSubscriptionPlanMutation = useMutation({
     mutationFn: async (values: IUserSubscriptionPlanUpdate) => {
       const { userId, subscriptionId, ...payload } = values;
-      if (payload.status === 'active' && values.startDate) {
-        const date = new Date(values.startDate);
-        const now = new Date();
-        date.setHours(now.getHours(), now.getMinutes(), now.getSeconds(), now.getMilliseconds());
-        const adjustedStartDate = date.toISOString();
-        payload.startDate = adjustedStartDate;
+      if (payload.startDate) {
+        const date = new Date(payload.startDate!);
+        date.setMinutes(date.getMinutes() + 1);
+        payload.startDate = date.toISOString();
       }
       const response = await axiosHandler.patch(`/admin/user/${userId}/subscription/${subscriptionId}`, payload)
       return response.data

--- a/src/app/i/users/[id]/_modals/SubscriptionModal.tsx
+++ b/src/app/i/users/[id]/_modals/SubscriptionModal.tsx
@@ -24,7 +24,7 @@ export default function SubscriptionModal({ user }: ISubscriptionModalProps) {
     initialValues: {
       subscriptionPlanId: '',
       userId: user.id,
-      startDate: new Date().toISOString().split('T')[0],
+      startDate: new Date().toISOString(),
     },
     onSubmit: (values) => {
       createUserSubscriptionPlanMutation.mutate(values, {
@@ -60,8 +60,8 @@ export default function SubscriptionModal({ user }: ISubscriptionModalProps) {
         <Input
           name='startDate'
           title='Start Date'
-          type='date'
-          min={new Date().toISOString().split('T')[0]}
+          type='datetime-local'
+          min={new Date().toISOString()}
           value={values.startDate}
           onChange={handleChange}
         />

--- a/src/app/i/users/[id]/page.tsx
+++ b/src/app/i/users/[id]/page.tsx
@@ -74,8 +74,8 @@ export default function UserPage({ params }: { params: { id: string } }) {
     { key: 'subscriptionPlan.name', value: 'Plan Name' },
     { key: 'status', value: 'Status', type: TableHeaderTypeEnum.STATUS },
     { key: 'autoRenewal', value: 'Auto Renewal', type: TableHeaderTypeEnum.BOOLEAN },
-    { key: 'startDate', value: 'Start Date', type: TableHeaderTypeEnum.DATE },
-    { key: 'endDate', value: 'End Date', type: TableHeaderTypeEnum.DATE },
+    { key: 'startDate', value: 'Start Date', type: TableHeaderTypeEnum.DATE_TIME },
+    { key: 'endDate', value: 'End Date', type: TableHeaderTypeEnum.DATE_TIME },
   ]
 
   const goToCourse = (course: IEnrolledCourse) => {

--- a/src/app/i/users/new/layout.tsx
+++ b/src/app/i/users/new/layout.tsx
@@ -1,0 +1,9 @@
+import { Fragment, ReactNode } from "react"
+
+export const metadata = {
+  title: 'New User | The Grind Academy'
+}
+
+export default function UsersLayout({ children }: { children: ReactNode }) {
+  return <Fragment>{children}</Fragment>
+}

--- a/src/app/i/users/new/page.tsx
+++ b/src/app/i/users/new/page.tsx
@@ -135,7 +135,7 @@ export default function NewUserPage() {
           <Input
             name='startDate'
             title='Start Date'
-            type='date'
+            type='datetime-local'
             min={new Date().toISOString().split('T')[0]}
             value={values.startDate}
             onChange={handleChange}


### PR DESCRIPTION
Changed subscription start and end date fields to use datetime instead of date only, updating input types and min values accordingly. Adjusted mutation logic to increment startDate by one minute and simplified date handling. Added layout file for new user page.