### PR TITLE
Replace Image with Video component for media display

### DIFF
--- a/src/app/i/website-content/student-interviews/[id]/page.tsx
+++ b/src/app/i/website-content/student-interviews/[id]/page.tsx
@@ -10,7 +10,6 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import FileUploader from '@/components/FileUploader';
-import Image from 'next/image';
 import notificationUtil from '@/utils/notification.util';
 import { useRouter } from 'next/navigation';
 import helperUtil from '@/utils/helper.util';
@@ -20,6 +19,7 @@ import LoadingIcons from 'react-loading-icons';
 import { useTitle } from '@/providers/title.provider';
 import useStudentInterviewMutations from '../_apis/student-interview.mutations';
 import ConfirmStudentInterviewDeletionModal from './_modals/ConfirmStudentInterviewDeletionModal';
+import Video from '@/components/Video';
 
 export default function DynamicContentDetailPage({ params }: { params: { id: string } }) {
   const { id } = params;
@@ -123,7 +123,7 @@ export default function DynamicContentDetailPage({ params }: { params: { id: str
                 <p className='text-white text-sm'>Remove Video</p>
               </div>
             </div>
-            <Image src={values.mediaUrl} alt='Media' fill className='object-cover absolute' />
+            <Video src={values.mediaUrl} />
           </div>
         }
         <Button disabled={!isFormValid}


### PR DESCRIPTION
Swapped out the Next.js Image component for a custom Video component to render media content in the student interview detail page. This change ensures video files are displayed correctly instead of being treated as images.